### PR TITLE
Support custom Working Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following inputs are supported
 | `annotations`         | Annotate the project code with the knip results.                             | `false`  | `true`                                 |
 | `verbose`             | Include annotated items in the comment report.                               | `false`  | `false`                                |
 | `ignore_results`      | Do not fail the action run if knip results are found.                        | `false`  | `false`                                |
+| `working_directory`   | Run knip in a different directory.                                           | `false`  | `.`                                    |
 
 ### Issues
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Do not fail the action run if knip results are found.
     default: false
     required: false
+  working_directory:
+    description: Directory in which to run the knip action.
+    default: "."
+    required: false
 runs:
   using: node20
   main: dist/index.mjs

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -32,6 +32,7 @@ describe("Action", () => {
       annotations: actionInputs.annotations?.default,
       verbose: actionInputs.verbose?.default,
       ignore_results: actionInputs.ignore_results?.default,
+      working_directory: actionInputs.working_directory?.default,
     };
 
     vi.spyOn(core, "getInput").mockImplementation((input: string) => {
@@ -39,6 +40,7 @@ describe("Action", () => {
         case "token":
         case "command_script_name":
         case "comment_id":
+        case "working_directory":
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return mockEnvConfig[input];
         default:

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -75,6 +75,7 @@ describe("Action", () => {
         actionInputs.comment_id?.default.replaceAll(/\s/g, "-"),
       );
       expect(config.ignoreResults).toStrictEqual(actionInputs.ignore_results?.default);
+      expect(config.workingDirectory).toStrictEqual(actionInputs.working_directory?.default);
     });
 
     describe("custom values", () => {
@@ -132,6 +133,13 @@ describe("Action", () => {
         const config: ActionConfig = getConfig();
 
         expect(config.ignoreResults).toStrictEqual(true);
+      });
+
+      it("should load a custom value for workingDirectory", () => {
+        mockEnvConfig.working_directory = "some_directory";
+        const config: ActionConfig = getConfig();
+
+        expect(config.workingDirectory).toStrictEqual("some_directory");
       });
     });
   });

--- a/src/action.ts
+++ b/src/action.ts
@@ -33,6 +33,11 @@ export interface ActionConfig {
    * Do not fail the action run if knip results are found.
    */
   ignoreResults: boolean;
+
+  /**
+   * Directory in which to run the knip action.
+   */
+  workingDirectory: string;
 }
 
 export function getConfig(): ActionConfig {
@@ -43,6 +48,7 @@ export function getConfig(): ActionConfig {
     annotations: core.getBooleanInput("annotations", { required: false }),
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
+    workingDirectory: core.getInput("working_directory", { required: false }) || ".",
   };
 }
 
@@ -54,5 +60,6 @@ export function configToStr(cfg: ActionConfig): string {
     annotations: ${cfg.annotations}
     verbose: ${cfg.verbose}
     ignoreResults: ${cfg.ignoreResults}
+    workingDirectory: ${cfg.workingDirectory}
 `;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -37,7 +37,7 @@ export interface ActionConfig {
   /**
    * Directory in which to run the knip action.
    */
-  workingDirectory: string;
+  workingDirectory?: string;
 }
 
 export function getConfig(): ActionConfig {
@@ -48,7 +48,7 @@ export function getConfig(): ActionConfig {
     annotations: core.getBooleanInput("annotations", { required: false }),
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
-    workingDirectory: core.getInput("working_directory", { required: false }) || ".",
+    workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
   };
 }
 

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -66,6 +66,7 @@ describe("API", () => {
     annotations: true,
     verbose: false,
     ignoreResults: false,
+    workingDirectory: ".",
   };
 
   beforeEach(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ async function run(): Promise<void> {
       config.commandScriptName,
       config.annotations,
       config.verbose,
+      config.workingDirectory,
     );
 
     await runCommentTask(

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -8,9 +8,10 @@ import { GITHUB_COMMENT_MAX_COMMENT_LENGTH } from "../api.ts";
 import { timeTask } from "./task.ts";
 import type { ItemMeta } from "./types.ts";
 
-export async function buildRunKnipCommand(buildScriptName: string): Promise<string> {
+export async function buildRunKnipCommand(buildScriptName: string, cwd: string): Promise<string> {
   const cmd = await getCliCommand(parseNr, [buildScriptName, "--reporter json"], {
     programmatic: true,
+    cwd,
   });
   if (!cmd) {
     throw new Error("Unable to generate command for package manager");
@@ -548,11 +549,12 @@ export async function runKnipTasks(
   buildScriptName: string,
   annotationsEnabled: boolean,
   verboseEnabled: boolean,
+  cwd: string,
 ): Promise<{ sections: string[]; annotations: ItemMeta[] }> {
   const taskMs = Date.now();
   core.info("- Running Knip tasks");
 
-  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName));
+  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
   const output = await timeTask("Run knip", async () => getJsonFromOutput(await run(cmd)));
   const report = await timeTask("Parse knip report", () =>
     Promise.resolve(parseJsonReport(output)),

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -552,7 +552,7 @@ export async function runKnipTasks(
   buildScriptName: string,
   annotationsEnabled: boolean,
   verboseEnabled: boolean,
-  cwd: string,
+  cwd?: string,
 ): Promise<{ sections: string[]; annotations: ItemMeta[] }> {
   const taskMs = Date.now();
   core.info("- Running Knip tasks");

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -9,9 +9,12 @@ import { timeTask } from "./task.ts";
 import type { ItemMeta } from "./types.ts";
 
 export async function buildRunKnipCommand(buildScriptName: string, cwd?: string): Promise<string> {
-  const cmd = await getCliCommand(parseNr, [buildScriptName, "--reporter json"], {
+  const knipArgs = [buildScriptName, "--reporter json"];
+  if (cwd) {
+    knipArgs.push(`--directory ${cwd}`);
+  }
+  const cmd = await getCliCommand(parseNr, knipArgs, {
     programmatic: true,
-    cwd,
   });
   if (!cmd) {
     throw new Error("Unable to generate command for package manager");

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -8,7 +8,7 @@ import { GITHUB_COMMENT_MAX_COMMENT_LENGTH } from "../api.ts";
 import { timeTask } from "./task.ts";
 import type { ItemMeta } from "./types.ts";
 
-export async function buildRunKnipCommand(buildScriptName: string, cwd: string): Promise<string> {
+export async function buildRunKnipCommand(buildScriptName: string, cwd?: string): Promise<string> {
   const cmd = await getCliCommand(parseNr, [buildScriptName, "--reporter json"], {
     programmatic: true,
     cwd,


### PR DESCRIPTION
This adds a `working_directory` configuration option so you can run `knip` on different directories. It is not required and falls back to the current directory if not specified.

Fixes #23 