### PR TITLE
feat: run from existing report

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/codex-/knip-reporter/ci.yml?style=flat-square)](https://github.com/Codex-/knip-reporter/actions/workflows/ci.yml) [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-knip–reporter-blue?style=flat-square&logo=github&link=https%3A%2F%2Fgithub.com%2Fmarketplace%2Factions%2Fawait-remote-run)](https://github.com/marketplace/actions/knip-reporter)
 
-This action runs [knip](https://github.com/webpro/knip), parses the results, and posts the report as comments on the related pull request.
+This action posts a [knip](https://github.com/webpro/knip) report as comments on a pull request. It can run `knip` itself, or consume an existing report.
 
 ## Usage
+
+There are two primary ways to use this action, which will depend on your requirements. This action can run `knip` itself (default), or you can use `knip` to generate the report. Once a report has been generated/provided, this action works with that report.
+
+### Generate the report
 
 The execution of `knip` requires you to have followed the general `knip` setup and have a command script present in your `package.json` file, `knip`, by default but this can be of any name. If this script name deviates from the standard `knip` setup, please provide the script name in the config.
 
@@ -26,6 +30,35 @@ permissions:
 steps:
   - name: Post the knip results
     uses: codex-/knip-reporter@v3
+```
+
+### Provide the report
+
+If you wish to avoid having this action run any commands itself, you can provide the path to an existing report for `knip-reporter` to work with.
+
+The provided report must be generated with the JSON reporter (using `--reporter json`)
+
+```yaml
+name: Pull Request
+on:
+  pull_request:
+
+# This permissions config is only required if you are
+# not providing own permissive token
+permissions:
+  checks: write
+  pull-requests: write
+
+steps:
+  - name: Generate the knip report
+    # `--silent` will stop the wrapping output from pnpm, leaving just the report
+    run: pnpm --silent knip --reporter json > knip-report.json
+    continue-on-error: true # Any reports generated with content result in a non-zero exit code
+
+  - name: Post the knip results
+    uses: codex-/knip-reporter@v3
+    with:
+      json_report_path: ./knip-report.json
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ steps:
 
 The following inputs are supported
 
-| Input                 | Description                                                                  | Required | Default                                |
-| --------------------- | ---------------------------------------------------------------------------- | -------- | -------------------------------------- |
-| `token`               | GitHub Personal Access Token for making API requests.                        | `false`  | `${{ github.token }}`                  |
-| `command_script_name` | The package script that runs knip.                                           | `false`  | `knip`                                 |
-| `comment_id`          | ID to use when updating the PR comment. Spaces will be replaced with dashes. | `false`  | `${{ github.workflow }}-knip-reporter` |
-| `annotations`         | Annotate the project code with the knip results.                             | `false`  | `true`                                 |
-| `verbose`             | Include annotated items in the comment report.                               | `false`  | `false`                                |
-| `ignore_results`      | Do not fail the action run if knip results are found.                        | `false`  | `false`                                |
-| `working_directory`   | Run knip in a different directory.                                           | `false`  | `.`                                    |
-| `json_report_path`    | Use a pre-existing knip report instead of running `knip`                     | `false`  | `undefined`                            |
+| Input                 | Description                                                                                                        | Required | Default                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | -------------------------------------- |
+| `token`               | GitHub Personal Access Token for making API requests.                                                              | `false`  | `${{ github.token }}`                  |
+| `command_script_name` | The package script that runs knip.                                                                                 | `false`  | `knip`                                 |
+| `comment_id`          | ID to use when updating the PR comment. Spaces will be replaced with dashes.                                       | `false`  | `${{ github.workflow }}-knip-reporter` |
+| `annotations`         | Annotate the project code with the knip results.                                                                   | `false`  | `true`                                 |
+| `verbose`             | Include annotated items in the comment report.                                                                     | `false`  | `false`                                |
+| `ignore_results`      | Do not fail the action run if knip results are found.                                                              | `false`  | `false`                                |
+| `working_directory`   | Run knip in a different directory.                                                                                 | `false`  | `.`                                    |
+| `json_report_path`    | Use a pre-existing knip report instead of running `knip`. Relative paths are resolved against `working_directory`. | `false`  |                                        |
 
 ### Issues
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following inputs are supported
 | `verbose`             | Include annotated items in the comment report.                               | `false`  | `false`                                |
 | `ignore_results`      | Do not fail the action run if knip results are found.                        | `false`  | `false`                                |
 | `working_directory`   | Run knip in a different directory.                                           | `false`  | `.`                                    |
+| `json_report_path`    | Use a pre-existing knip report instead of running `knip`                     | `false`  | `undefined`                            |
 
 ### Issues
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Directory in which to run the knip action.
     default: "."
     required: false
-  output_json_file:
+  json_report_path:
     description: |
       Optional file path containing the results from a knip run.
       If provided, the action will read from this file instead of running knip itself.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
     description: Directory in which to run the knip action.
     default: "."
     required: false
+  output_json_file:
+    description: |
+      Optional file path containing the results from a knip run.
+      If provided, the action will read from this file instead of running knip itself.
+    required: false
 runs:
   using: node24
   main: dist/index.mjs

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -23727,22 +23727,19 @@ function getOctokit(token, options, ...additionalPlugins) {
 
 // src/action.ts
 import path from "node:path";
+var DEFAULT_KNIP_COMMAND = "knip";
 function getConfig() {
+  const workingDirectory = getInput("working_directory", { required: false }) || void 0;
+  const jsonReportPathInput = getInput("json_report_path", { required: false });
   return {
     token: getInput("token", { required: true }),
-    commandScriptName: getInput("command_script_name", { required: false }) || "knip",
+    commandScriptName: getInput("command_script_name", { required: false }) || DEFAULT_KNIP_COMMAND,
     commentId: getInput("comment_id", { required: true }).trim().replaceAll(/\s/g, "-"),
     annotations: getBooleanInput("annotations", { required: false }),
     verbose: getBooleanInput("verbose", { required: false }),
     ignoreResults: getBooleanInput("ignore_results", { required: false }),
-    workingDirectory: getInput("working_directory", { required: false }) || void 0,
-    get jsonReportPath() {
-      const input = getInput("json_report_path", { required: false });
-      if (!input) {
-        return void 0;
-      }
-      return path.resolve(input);
-    }
+    workingDirectory,
+    jsonReportPath: jsonReportPathInput ? path.resolve(workingDirectory ?? ".", jsonReportPathInput) : void 0
   };
 }
 function configToStr(cfg) {
@@ -28463,28 +28460,31 @@ function getJsonFromOutput(output) {
 async function getJsonFromInputFile(filePath) {
   try {
     await fs4.stat(filePath);
-  } catch {
-    throw new Error(`Provided jsonReportPath does not exist: ${filePath}`);
+  } catch (err) {
+    throw new Error(`Provided 'json_report_path' does not exist: ${filePath}`, { cause: err });
   }
   const content = await fs4.readFile(filePath, "utf-8");
   if (!content) {
-    throw new Error(`Provided jsonReportPath is empty: ${filePath}`);
+    throw new Error(`Provided 'json_report_path' is empty: ${filePath}`);
   }
   try {
     JSON.parse(content);
   } catch {
-    throw new Error(`Provided jsonReportPath contains invalid JSON: ${filePath}`);
+    throw new Error(`Provided 'json_report_path' content contains invalid JSON: ${filePath}`);
   }
   return content;
 }
 async function getOutput(buildScriptName, cwd) {
-  if (!buildScriptName) {
-    throw new Error("No command script name provided to run Knip, unable to proceed");
-  }
   const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
   return getJsonFromOutput(await run2(cmd));
 }
-async function runKnipTasks(buildScriptName, jsonReportPath, annotationsEnabled, verboseEnabled, cwd) {
+async function runKnipTasks({
+  buildScriptName,
+  jsonReportPath,
+  annotationsEnabled,
+  verboseEnabled,
+  cwd
+}) {
   const taskMs = Date.now();
   info("- Running Knip tasks");
   const output = jsonReportPath ? await timeTask("Get knip report from file", () => getJsonFromInputFile(jsonReportPath)) : await timeTask("Run knip", () => getOutput(buildScriptName, cwd));
@@ -28505,7 +28505,7 @@ async function main() {
   try {
     const config3 = getConfig();
     const actionMs = Date.now();
-    if (config3.jsonReportPath && config3.commandScriptName !== "knip") {
+    if (config3.jsonReportPath && config3.commandScriptName !== DEFAULT_KNIP_COMMAND) {
       warning("command_script_name config will be ignored when json_report_path is provided");
     }
     info("- knip-reporter action");
@@ -28523,13 +28523,13 @@ async function main() {
         () => createCheckId("knip-reporter-annotations-check", "Knip reporter analysis")
       );
     }
-    const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks(
-      config3.commandScriptName,
-      config3.jsonReportPath,
-      config3.annotations,
-      config3.verbose,
-      config3.workingDirectory
-    );
+    const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks({
+      buildScriptName: config3.commandScriptName,
+      jsonReportPath: config3.jsonReportPath,
+      annotationsEnabled: config3.annotations,
+      verboseEnabled: config3.verbose,
+      cwd: config3.workingDirectory
+    });
     await runCommentTask(
       config3.commentId,
       context2.payload.pull_request.number,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -23734,7 +23734,8 @@ function getConfig() {
     annotations: getBooleanInput("annotations", { required: false }),
     verbose: getBooleanInput("verbose", { required: false }),
     ignoreResults: getBooleanInput("ignore_results", { required: false }),
-    workingDirectory: getInput("working_directory", { required: false }) || void 0
+    workingDirectory: getInput("working_directory", { required: false }) || void 0,
+    jsonReportPath: getInput("json_report_path", { required: false }) || void 0
   };
 }
 function configToStr(cfg) {
@@ -23746,6 +23747,7 @@ function configToStr(cfg) {
     verbose: ${cfg.verbose}
     ignoreResults: ${cfg.ignoreResults}
     workingDirectory: ${cfg.workingDirectory}
+    jsonReportPath: ${cfg.jsonReportPath}
 `;
 }
 
@@ -24253,6 +24255,7 @@ async function runCommentTask(cfgCommentId, pullRequestNumber, reportSections) {
 
 // src/tasks/knip.ts
 import { exec } from "node:child_process";
+import fs4 from "node:fs/promises";
 
 // node_modules/.pnpm/@antfu+ni@30.1.0/node_modules/@antfu/ni/dist/chunk-CMuxRQOh.mjs
 import { createRequire } from "node:module";
@@ -28450,11 +28453,34 @@ function getJsonFromOutput(output) {
   }
   throw new Error("Unable to find JSON blob");
 }
-async function runKnipTasks(buildScriptName, annotationsEnabled, verboseEnabled, cwd) {
+async function getJsonFromInputFile(filePath) {
+  try {
+    await fs4.stat(filePath);
+  } catch {
+    throw new Error(`Provided jsonReportPath does not exist: ${filePath}`);
+  }
+  const content = await fs4.readFile(filePath, "utf-8");
+  if (!content) {
+    throw new Error(`Provided jsonReportPath is empty: ${filePath}`);
+  }
+  try {
+    JSON.parse(content);
+  } catch {
+    throw new Error(`Provided jsonReportPath contains invalid JSON: ${filePath}`);
+  }
+  return content;
+}
+async function getOutput(buildScriptName, cwd) {
+  if (!buildScriptName) {
+    throw new Error("No command script name provided to run Knip, unable to proceed");
+  }
+  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
+  return getJsonFromOutput(await run2(cmd));
+}
+async function runKnipTasks(buildScriptName, jsonReportPath, annotationsEnabled, verboseEnabled, cwd) {
   const taskMs = Date.now();
   info("- Running Knip tasks");
-  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
-  const output = await timeTask("Run knip", async () => getJsonFromOutput(await run2(cmd)));
+  const output = jsonReportPath ? await timeTask("Get knip report from file", () => getJsonFromInputFile(jsonReportPath)) : await timeTask("Run knip", () => getOutput(buildScriptName, cwd));
   const report = await timeTask(
     "Parse knip report",
     () => Promise.resolve(parseJsonReport(output))
@@ -28472,6 +28498,9 @@ async function main() {
   try {
     const config3 = getConfig();
     const actionMs = Date.now();
+    if (config3.jsonReportPath && config3.commandScriptName !== "knip") {
+      warning("command_script_name config will be ignored when json_report_path is provided");
+    }
     info("- knip-reporter action");
     info(configToStr(config3));
     if (context2.payload.pull_request === void 0) {
@@ -28489,6 +28518,7 @@ async function main() {
     }
     const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks(
       config3.commandScriptName,
+      config3.jsonReportPath,
       config3.annotations,
       config3.verbose,
       config3.workingDirectory

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1075,14 +1075,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol || ""}//${url.hostname || ""}:${port}`;
-        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path3 && path3[0] !== "/") {
-          path3 = `/${path3}`;
+        if (path4 && path4[0] !== "/") {
+          path4 = `/${path4}`;
         }
-        return new URL(`${origin}${path3}`);
+        return new URL(`${origin}${path4}`);
       }
       if (!isHttpOrHttpsPrefixed(url.origin || url.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1533,39 +1533,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path3, origin }
+          request: { method, path: path4, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path3);
+        debuglog("sending request to %s %s/%s", method, origin, path4);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path3, origin },
+          request: { method, path: path4, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path3,
+          path4,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path3, origin }
+          request: { method, path: path4, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path3);
+        debuglog("trailers received from %s %s/%s", method, origin, path4);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path3, origin },
+          request: { method, path: path4, origin },
           error: error2
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path3,
+          path4,
           error2.message
         );
       });
@@ -1614,9 +1614,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path3, origin }
+            request: { method, path: path4, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path3);
+          debuglog("sending request to %s %s/%s", method, origin, path4);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1679,7 +1679,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -1694,11 +1694,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler2) {
-        if (typeof path3 !== "string") {
+        if (typeof path4 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path3)) {
+        } else if (invalidPathRegex.test(path4)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -1764,7 +1764,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path3, query) : path3;
+        this.path = query ? buildURL(path4, query) : path4;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6290,7 +6290,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request2) {
-      const { method, path: path3, host, upgrade, blocking, reset } = request2;
+      const { method, path: path4, host, upgrade, blocking, reset } = request2;
       let { body, headers, contentLength } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util.isFormDataLike(body)) {
@@ -6356,7 +6356,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path3} HTTP/1.1\r
+      let header = `${method} ${path4} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -6882,7 +6882,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request2) {
       const session = client[kHTTP2Session];
-      const { method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let { body } = request2;
       if (upgrade) {
         util.errorRequest(client, request2, new Error("Upgrade not supported for H2"));
@@ -6949,7 +6949,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path3;
+      headers[HTTP2_HEADER_PATH] = path4;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7302,9 +7302,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path3 = search ? `${pathname}${search}` : pathname;
+        const path4 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path3;
+        this.opts.path = path4;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8539,10 +8539,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path3 = "/",
+          path: path4 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path3;
+        opts.path = origin + path4;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10463,20 +10463,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path3) {
-      if (typeof path3 !== "string") {
-        return path3;
+    function safeUrl(path4) {
+      if (typeof path4 !== "string") {
+        return path4;
       }
-      const pathSegments = path3.split("?");
+      const pathSegments = path4.split("?");
       if (pathSegments.length !== 2) {
-        return path3;
+        return path4;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path3);
+    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path4);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10498,7 +10498,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10536,9 +10536,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path3, method, body, headers, query } = opts;
+      const { path: path4, method, body, headers, query } = opts;
       return {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -11001,10 +11001,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path3,
+            Path: path4,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -15885,9 +15885,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path3) {
-      for (let i2 = 0; i2 < path3.length; ++i2) {
-        const code = path3.charCodeAt(i2);
+    function validateCookiePath(path4) {
+      for (let i2 = 0; i2 < path4.length; ++i2) {
+        const code = path4.charCodeAt(i2);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18564,11 +18564,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path3 = opts.path;
+          let path4 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path3 = `/${path3}`;
+            path4 = `/${path4}`;
           }
-          url = new URL(util.parseOrigin(url).origin + path3);
+          url = new URL(util.parseOrigin(url).origin + path4);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -19994,8 +19994,8 @@ var Context = class {
       if (existsSync(process.env.GITHUB_EVENT_PATH)) {
         this.payload = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
       } else {
-        const path3 = process.env.GITHUB_EVENT_PATH;
-        process.stdout.write(`GITHUB_EVENT_PATH ${path3} does not exist${EOL4}`);
+        const path4 = process.env.GITHUB_EVENT_PATH;
+        process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${EOL4}`);
       }
     }
     this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -23726,6 +23726,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 }
 
 // src/action.ts
+import path from "node:path";
 function getConfig() {
   return {
     token: getInput("token", { required: true }),
@@ -23735,7 +23736,13 @@ function getConfig() {
     verbose: getBooleanInput("verbose", { required: false }),
     ignoreResults: getBooleanInput("ignore_results", { required: false }),
     workingDirectory: getInput("working_directory", { required: false }) || void 0,
-    jsonReportPath: getInput("json_report_path", { required: false }) || void 0
+    get jsonReportPath() {
+      const input = getInput("json_report_path", { required: false });
+      if (!input) {
+        return void 0;
+      }
+      return path.resolve(input);
+    }
   };
 }
 function configToStr(cfg) {
@@ -24294,7 +24301,7 @@ var __require2 = /* @__PURE__ */ createRequire(import.meta.url);
 
 // node_modules/.pnpm/@antfu+ni@30.1.0/node_modules/@antfu/ni/dist/src-Dc2SIy_D.mjs
 import fs3, { existsSync as existsSync2, promises as promises3 } from "node:fs";
-import path2, { dirname, join, resolve } from "node:path";
+import path3, { dirname, join, resolve } from "node:path";
 import process$1 from "node:process";
 
 // node_modules/.pnpm/package-manager-detector@1.6.0/node_modules/package-manager-detector/dist/commands.mjs
@@ -24490,7 +24497,7 @@ var INSTALL_PAGE = {
 
 // node_modules/.pnpm/package-manager-detector@1.6.0/node_modules/package-manager-detector/dist/detect.mjs
 import fs2 from "node:fs/promises";
-import path from "node:path";
+import path2 from "node:path";
 import process2 from "node:process";
 async function pathExists(path22, type) {
   try {
@@ -24501,11 +24508,11 @@ async function pathExists(path22, type) {
   }
 }
 function* lookup(cwd = process2.cwd()) {
-  let directory = path.resolve(cwd);
-  const { root } = path.parse(directory);
+  let directory = path2.resolve(cwd);
+  const { root } = path2.parse(directory);
   while (directory && directory !== root) {
     yield directory;
-    directory = path.dirname(directory);
+    directory = path2.dirname(directory);
   }
 }
 async function parsePackageJson(filepath, options) {
@@ -24520,7 +24527,7 @@ async function detect(options = {}) {
   } = options;
   let stopDir;
   if (typeof options.stopDir === "string") {
-    const resolved = path.resolve(options.stopDir);
+    const resolved = path2.resolve(options.stopDir);
     stopDir = (dir) => dir === resolved;
   } else {
     stopDir = options.stopDir;
@@ -24530,9 +24537,9 @@ async function detect(options = {}) {
       switch (strategy) {
         case "lockfile": {
           for (const lock of Object.keys(LOCKS)) {
-            if (await pathExists(path.join(directory, lock), "file")) {
+            if (await pathExists(path2.join(directory, lock), "file")) {
               const name = LOCKS[lock];
-              const result = await parsePackageJson(path.join(directory, "package.json"), options);
+              const result = await parsePackageJson(path2.join(directory, "package.json"), options);
               if (result)
                 return result;
               else
@@ -24543,7 +24550,7 @@ async function detect(options = {}) {
         }
         case "packageManager-field":
         case "devEngines-field": {
-          const result = await parsePackageJson(path.join(directory, "package.json"), options);
+          const result = await parsePackageJson(path2.join(directory, "package.json"), options);
           if (result)
             return result;
           break;
@@ -24551,7 +24558,7 @@ async function detect(options = {}) {
         case "install-metadata": {
           for (const metadata of Object.keys(INSTALL_METADATA)) {
             const fileOrDir = metadata.endsWith("/") ? "dir" : "file";
-            if (await pathExists(path.join(directory, metadata), fileOrDir)) {
+            if (await pathExists(path2.join(directory, metadata), fileOrDir)) {
               const name = INSTALL_METADATA[metadata];
               const agent = name === "yarn" ? isMetadataYarnClassic(metadata) ? "yarn" : "yarn@berry" : name;
               return { name, agent };
@@ -27655,12 +27662,12 @@ async function openTemp() {
     else return void 0;
   });
 }
-async function writeFileSafe(path3, data = "") {
+async function writeFileSafe(path4, data = "") {
   const temp = await openTemp();
   if (temp) promises3.writeFile(temp.path, data).then(() => {
-    const directory = dirname(path3);
+    const directory = dirname(path4);
     if (!existsSync2(directory)) promises3.mkdir(directory, { recursive: true });
-    return promises3.rename(temp.path, path3).then(() => true).catch(() => false);
+    return promises3.rename(temp.path, path4).then(() => true).catch(() => false);
   }).catch(() => false).finally(temp.cleanup);
   return false;
 }
@@ -27679,7 +27686,7 @@ function formatPackageWithUrl(pkg, url, limits = 80) {
 var import_prompts = /* @__PURE__ */ __toESM2(require_prompts(), 1);
 async function detect$1({ autoInstall, programmatic, cwd } = {}) {
   const targetDir = cwd ?? process$1.cwd();
-  if (existsSync2(path2.join(targetDir, "deno.json")) || existsSync2(path2.join(targetDir, "deno.jsonc"))) return "deno";
+  if (existsSync2(path3.join(targetDir, "deno.json")) || existsSync2(path3.join(targetDir, "deno.jsonc"))) return "deno";
   const { name, agent, version: version2 } = await detect({
     cwd,
     onUnknown: (packageManager) => {
@@ -27715,7 +27722,7 @@ async function detect$1({ autoInstall, programmatic, cwd } = {}) {
 var import_ini = /* @__PURE__ */ __toESM2(require_ini(), 1);
 var customRcPath = process$1.env.NI_CONFIG_FILE;
 var home = process$1.platform === "win32" ? process$1.env.USERPROFILE : process$1.env.HOME;
-var defaultRcPath = path2.join(home || "~/", ".nirc");
+var defaultRcPath = path3.join(home || "~/", ".nirc");
 var rcPath = customRcPath || defaultRcPath;
 var defaultConfig = {
   defaultAgent: "prompt",

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -176,5 +176,11 @@ describe("Action", () => {
       expect(cfgStr).not.toContain(actionInputs.token?.default);
       expect(cfgStr).not.toContain(mockEnvConfig.token);
     });
+
+    it("should include the resolved jsonReportPath when one is provided", () => {
+      mockEnvConfig.json_report_path = "report.json";
+      const cfgStr = configToStr(getConfig());
+      expect(cfgStr).toContain(resolve("report.json"));
+    });
   });
 });

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -33,6 +33,7 @@ describe("Action", () => {
       verbose: actionInputs.verbose?.default,
       ignore_results: actionInputs.ignore_results?.default,
       working_directory: actionInputs.working_directory?.default,
+      output_json_file: actionInputs.output_json_file?.default,
     };
 
     vi.spyOn(core, "getInput").mockImplementation((input: string) => {
@@ -41,6 +42,7 @@ describe("Action", () => {
         case "command_script_name":
         case "comment_id":
         case "working_directory":
+        case "output_json_file":
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return mockEnvConfig[input];
         default:
@@ -76,6 +78,7 @@ describe("Action", () => {
       );
       expect(config.ignoreResults).toStrictEqual(actionInputs.ignore_results?.default);
       expect(config.workingDirectory).toStrictEqual(actionInputs.working_directory?.default);
+      expect(config.outputJsonFile).toStrictEqual(actionInputs.output_json_file?.default);
     });
 
     describe("custom values", () => {

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -33,7 +33,7 @@ describe("Action", () => {
       verbose: actionInputs.verbose?.default,
       ignore_results: actionInputs.ignore_results?.default,
       working_directory: actionInputs.working_directory?.default,
-      output_json_file: actionInputs.output_json_file?.default,
+      json_report_path: actionInputs.json_report_path?.default,
     };
 
     vi.spyOn(core, "getInput").mockImplementation((input: string) => {
@@ -42,7 +42,7 @@ describe("Action", () => {
         case "command_script_name":
         case "comment_id":
         case "working_directory":
-        case "output_json_file":
+        case "json_report_path":
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return mockEnvConfig[input];
         default:
@@ -78,7 +78,7 @@ describe("Action", () => {
       );
       expect(config.ignoreResults).toStrictEqual(actionInputs.ignore_results?.default);
       expect(config.workingDirectory).toStrictEqual(actionInputs.working_directory?.default);
-      expect(config.outputJsonFile).toStrictEqual(actionInputs.output_json_file?.default);
+      expect(config.jsonReportPath).toStrictEqual(actionInputs.json_report_path?.default);
     });
 
     describe("custom values", () => {

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -144,6 +144,29 @@ describe("Action", () => {
 
         expect(config.workingDirectory).toStrictEqual("some_directory");
       });
+
+      it("should resolve jsonReportPath against process.cwd when workingDirectory is unset", () => {
+        mockEnvConfig.json_report_path = "report.json";
+        const config: ActionConfig = getConfig();
+
+        expect(config.jsonReportPath).toStrictEqual(resolve("report.json"));
+      });
+
+      it("should resolve a relative jsonReportPath against workingDirectory", () => {
+        mockEnvConfig.working_directory = "packages/app";
+        mockEnvConfig.json_report_path = "report.json";
+        const config: ActionConfig = getConfig();
+
+        expect(config.jsonReportPath).toStrictEqual(resolve("packages/app", "report.json"));
+      });
+
+      it("should keep an absolute jsonReportPath unchanged regardless of workingDirectory", () => {
+        mockEnvConfig.working_directory = "packages/app";
+        mockEnvConfig.json_report_path = "/tmp/report.json";
+        const config: ActionConfig = getConfig();
+
+        expect(config.jsonReportPath).toStrictEqual("/tmp/report.json");
+      });
     });
   });
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,6 @@
-import * as core from "@actions/core";
 import path from "node:path";
+
+import * as core from "@actions/core";
 
 export const DEFAULT_KNIP_COMMAND = "knip";
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -44,7 +44,7 @@ export interface ActionConfig {
    *
    * If provided, the action will use this instead of running Knip.
    */
-  outputJsonFile?: string;
+  jsonReportPath?: string;
 }
 
 export function getConfig(): ActionConfig {
@@ -56,7 +56,7 @@ export function getConfig(): ActionConfig {
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
     workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
-    outputJsonFile: core.getInput("output_json_file", { required: false }) || undefined,
+    jsonReportPath: core.getInput("json_report_path", { required: false }) || undefined,
   };
 }
 
@@ -69,6 +69,6 @@ export function configToStr(cfg: ActionConfig): string {
     verbose: ${cfg.verbose}
     ignoreResults: ${cfg.ignoreResults}
     workingDirectory: ${cfg.workingDirectory}
-    outputJsonFile: ${cfg.outputJsonFile}
+    jsonReportPath: ${cfg.jsonReportPath}
 `;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,8 @@
 import * as core from "@actions/core";
 import path from "node:path";
 
+export const DEFAULT_KNIP_COMMAND = "knip";
+
 /**
  * action.yaml definition.
  */
@@ -54,7 +56,8 @@ export function getConfig(): ActionConfig {
 
   return {
     token: core.getInput("token", { required: true }),
-    commandScriptName: core.getInput("command_script_name", { required: false }) || "knip",
+    commandScriptName:
+      core.getInput("command_script_name", { required: false }) || DEFAULT_KNIP_COMMAND,
     commentId: core.getInput("comment_id", { required: true }).trim().replaceAll(/\s/g, "-"),
     annotations: core.getBooleanInput("annotations", { required: false }),
     verbose: core.getBooleanInput("verbose", { required: false }),

--- a/src/action.ts
+++ b/src/action.ts
@@ -49,6 +49,7 @@ export interface ActionConfig {
 }
 
 export function getConfig(): ActionConfig {
+  const workingDirectory = core.getInput("working_directory", { required: false }) || undefined;
   const jsonReportPathInput = core.getInput("json_report_path", { required: false });
 
   return {
@@ -58,8 +59,10 @@ export function getConfig(): ActionConfig {
     annotations: core.getBooleanInput("annotations", { required: false }),
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
-    workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
-    jsonReportPath: jsonReportPathInput ? path.resolve(jsonReportPathInput) : undefined,
+    workingDirectory,
+    jsonReportPath: jsonReportPathInput
+      ? path.resolve(workingDirectory ?? ".", jsonReportPathInput)
+      : undefined,
   };
 }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import path from "node:path";
 
 /**
  * action.yaml definition.
@@ -56,7 +57,15 @@ export function getConfig(): ActionConfig {
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
     workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
-    jsonReportPath: core.getInput("json_report_path", { required: false }) || undefined,
+    get jsonReportPath(): string | undefined {
+      const input = core.getInput("json_report_path", { required: false });
+
+      if (!input) {
+        return undefined;
+      }
+
+      return path.resolve(input);
+    },
   };
 }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -49,6 +49,8 @@ export interface ActionConfig {
 }
 
 export function getConfig(): ActionConfig {
+  const jsonReportPathInput = core.getInput("json_report_path", { required: false });
+
   return {
     token: core.getInput("token", { required: true }),
     commandScriptName: core.getInput("command_script_name", { required: false }) || "knip",
@@ -57,15 +59,7 @@ export function getConfig(): ActionConfig {
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
     workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
-    get jsonReportPath(): string | undefined {
-      const input = core.getInput("json_report_path", { required: false });
-
-      if (!input) {
-        return undefined;
-      }
-
-      return path.resolve(input);
-    },
+    jsonReportPath: jsonReportPathInput ? path.resolve(jsonReportPathInput) : undefined,
   };
 }
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -38,6 +38,13 @@ export interface ActionConfig {
    * Directory in which to run the knip action.
    */
   workingDirectory?: string;
+
+  /**
+   * Path to a file that contains the JSON output of a Knip run.
+   *
+   * If provided, the action will use this instead of running Knip.
+   */
+  outputJsonFile?: string;
 }
 
 export function getConfig(): ActionConfig {
@@ -49,6 +56,7 @@ export function getConfig(): ActionConfig {
     verbose: core.getBooleanInput("verbose", { required: false }),
     ignoreResults: core.getBooleanInput("ignore_results", { required: false }),
     workingDirectory: core.getInput("working_directory", { required: false }) || undefined,
+    outputJsonFile: core.getInput("output_json_file", { required: false }) || undefined,
   };
 }
 
@@ -61,5 +69,6 @@ export function configToStr(cfg: ActionConfig): string {
     verbose: ${cfg.verbose}
     ignoreResults: ${cfg.ignoreResults}
     workingDirectory: ${cfg.workingDirectory}
+    outputJsonFile: ${cfg.outputJsonFile}
 `;
 }

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -106,7 +106,13 @@ describe("main", () => {
     expect(apiInitMock).toHaveBeenCalledWith(expect.objectContaining({ annotations: true }));
 
     expect(createCheckIdMock).toHaveBeenCalledOnce();
-    expect(runKnipTasksMock).toHaveBeenCalledWith("knip", undefined, true, false, ".");
+    expect(runKnipTasksMock).toHaveBeenCalledWith({
+      buildScriptName: "knip",
+      jsonReportPath: undefined,
+      annotationsEnabled: true,
+      verboseEnabled: false,
+      cwd: ".",
+    });
     expect(runCommentTaskMock).toHaveBeenCalledWith("knip-report", 42, []);
     expect(updateCheckAnnotationsMock).toHaveBeenCalledWith(123, [], false);
 

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -106,7 +106,7 @@ describe("main", () => {
     expect(apiInitMock).toHaveBeenCalledWith(expect.objectContaining({ annotations: true }));
 
     expect(createCheckIdMock).toHaveBeenCalledOnce();
-    expect(runKnipTasksMock).toHaveBeenCalledWith("knip", true, false, ".");
+    expect(runKnipTasksMock).toHaveBeenCalledWith("knip", undefined, true, false, ".");
     expect(runCommentTaskMock).toHaveBeenCalledWith("knip-report", 42, []);
     expect(updateCheckAnnotationsMock).toHaveBeenCalledWith(123, [], false);
 

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -199,6 +199,44 @@ describe("main", () => {
     );
   });
 
+  it("should warn when both command_script_name and json_report_path are set", async () => {
+    actionGetConfigMock.mockReturnValue({
+      ...baseConfig,
+      commandScriptName: "custom:knip",
+      jsonReportPath: "/workspace/report.json",
+    });
+
+    // Behaviour
+    await main();
+    expect(runKnipTasksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonReportPath: "/workspace/report.json" }),
+    );
+
+    // Logging
+    assertOnlyCalled(coreInfoLogMock, coreWarningLogMock);
+    expect(coreWarningLogMock).toHaveBeenCalledOnce();
+    expect(coreWarningLogMock.mock.lastCall?.[0]).toMatch(
+      /command_script_name.*ignored.*json_report_path/,
+    );
+  });
+
+  it("should not warn when command_script_name is the default while json_report_path is set", async () => {
+    actionGetConfigMock.mockReturnValue({
+      ...baseConfig,
+      jsonReportPath: "/workspace/report.json",
+    });
+
+    // Behaviour
+    await main();
+    expect(runKnipTasksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonReportPath: "/workspace/report.json" }),
+    );
+
+    // Logging
+    assertOnlyCalled(coreInfoLogMock);
+    expect(coreWarningLogMock).not.toHaveBeenCalled();
+  });
+
   it("should preserve the findings setFailed message when resolveCheck throws", async () => {
     runKnipTasksMock.mockResolvedValue({
       sections: ["### Unused files\n\n`foo.ts`"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ export async function main(): Promise<void> {
 
     const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks(
       config.commandScriptName,
+      config.outputJsonFile,
       config.annotations,
       config.verbose,
       config.workingDirectory,

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ export async function main(): Promise<void> {
     const config = getConfig();
     const actionMs = Date.now();
 
-    if (config.outputJsonFile && config.commandScriptName !== "knip") {
-      core.warning("command_script_name config will be ignored when output_json_file is provided");
+    if (config.jsonReportPath && config.commandScriptName !== "knip") {
+      core.warning("command_script_name config will be ignored when json_report_path is provided");
     }
 
     core.info("- knip-reporter action");
@@ -42,7 +42,7 @@ export async function main(): Promise<void> {
 
     const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks(
       config.commandScriptName,
-      config.outputJsonFile,
+      config.jsonReportPath,
       config.annotations,
       config.verbose,
       config.workingDirectory,

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,10 @@ export async function main(): Promise<void> {
     const config = getConfig();
     const actionMs = Date.now();
 
+    if (config.outputJsonFile && config.commandScriptName !== "knip") {
+      core.warning("command_script_name config will be ignored when output_json_file is provided");
+    }
+
     core.info("- knip-reporter action");
     core.info(configToStr(config));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 
-import { configToStr, getConfig } from "./action.ts";
+import { configToStr, DEFAULT_KNIP_COMMAND, getConfig } from "./action.ts";
 import { init } from "./api.ts";
 import {
   AnnotationsCount,
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
     const config = getConfig();
     const actionMs = Date.now();
 
-    if (config.jsonReportPath && config.commandScriptName !== "knip") {
+    if (config.jsonReportPath && config.commandScriptName !== DEFAULT_KNIP_COMMAND) {
       core.warning("command_script_name config will be ignored when json_report_path is provided");
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,13 +40,13 @@ export async function main(): Promise<void> {
       );
     }
 
-    const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks(
-      config.commandScriptName,
-      config.jsonReportPath,
-      config.annotations,
-      config.verbose,
-      config.workingDirectory,
-    );
+    const { sections: knipSections, annotations: knipAnnotations } = await runKnipTasks({
+      buildScriptName: config.commandScriptName,
+      jsonReportPath: config.jsonReportPath,
+      annotationsEnabled: config.annotations,
+      verboseEnabled: config.verbose,
+      cwd: config.workingDirectory,
+    });
 
     await runCommentTask(
       config.commentId,

--- a/src/tasks/knip.spec.ts
+++ b/src/tasks/knip.spec.ts
@@ -29,6 +29,7 @@ import {
   parseJsonReport,
   processSectionToMessages,
   run,
+  runKnipTasks,
 } from "./knip.ts";
 
 vi.mock("node:child_process");
@@ -833,6 +834,44 @@ src/x.ts
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
         `Provided 'json_report_path' content contains invalid JSON: ${filePath}`,
       );
+    });
+  });
+
+  describe("runKnipTasks", () => {
+    it("should read the report from disk and skip knip when jsonReportPath is set", async () => {
+      vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
+      vi.spyOn(fs, "readFile").mockResolvedValueOnce(JSON.stringify(reportJson));
+      const execSpy = vi.spyOn(cp, "exec");
+
+      // Behaviour
+      const result = await runKnipTasks({
+        buildScriptName: "knip",
+        jsonReportPath: "report.json",
+        annotationsEnabled: false,
+        verboseEnabled: false,
+      });
+      expect(execSpy).not.toHaveBeenCalled();
+      expect(result.sections.length).toBeGreaterThan(0);
+    });
+
+    it("should execute knip when jsonReportPath is not set", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const execSpy = vi.spyOn(cp, "exec").mockImplementation(((
+        _cmd: string,
+        func: (error: any, stdout: string, stderr: string) => void,
+      ) => {
+        func(undefined, JSON.stringify(reportJson), "");
+      }) as any);
+
+      // Behaviour
+      const result = await runKnipTasks({
+        buildScriptName: "knip",
+        jsonReportPath: undefined,
+        annotationsEnabled: false,
+        verboseEnabled: false,
+      });
+      expect(execSpy).toHaveBeenCalledOnce();
+      expect(result.sections.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/tasks/knip.spec.ts
+++ b/src/tasks/knip.spec.ts
@@ -1,4 +1,6 @@
 import * as cp from "node:child_process";
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
 
 import * as ni from "@antfu/ni";
 import {
@@ -22,6 +24,7 @@ import {
   buildMarkdownSections,
   buildRunKnipCommand,
   buildSectionName,
+  getJsonFromInputFile,
   getJsonFromOutput,
   parseJsonReport,
   processSectionToMessages,
@@ -784,6 +787,49 @@ src/x.ts
 `;
       /* eslint-enable no-irregular-whitespace */
       expect(() => getJsonFromOutput(cliOutput)).toThrow("Unable to find JSON blob");
+    });
+  });
+
+  describe("getJsonFromInputFile", () => {
+    it("should read the report json from the provided file path", async () => {
+      vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
+      vi.spyOn(fs, "readFile").mockResolvedValueOnce(JSON.stringify(reportJson));
+
+      const jsonStr = await getJsonFromInputFile("knip-report.json");
+
+      expect(() => JSON.parse(jsonStr)).not.toThrow();
+    });
+
+    it("should throw an error if the file does not exist", async () => {
+      const filePath = "non-existent-file.json";
+
+      vi.spyOn(fs, "stat").mockRejectedValueOnce(new Error("File not found"));
+
+      await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
+        `Provided outputJsonFile does not exist: ${filePath}`,
+      );
+    });
+
+    it("should throw an error if the file is empty", async () => {
+      const filePath = "empty-file.json";
+
+      vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
+      vi.spyOn(fs, "readFile").mockResolvedValueOnce("");
+
+      await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
+        `Provided outputJsonFile is empty: ${filePath}`,
+      );
+    });
+
+    it("should throw an error if the file contains invalid JSON", async () => {
+      const filePath = "invalid-json-file.json";
+
+      vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
+      vi.spyOn(fs, "readFile").mockResolvedValueOnce("This is not JSON");
+
+      await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
+        `Provided outputJsonFile contains invalid JSON: ${filePath}`,
+      );
     });
   });
 });

--- a/src/tasks/knip.spec.ts
+++ b/src/tasks/knip.spec.ts
@@ -795,8 +795,8 @@ src/x.ts
       vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
       vi.spyOn(fs, "readFile").mockResolvedValueOnce(JSON.stringify(reportJson));
 
+      // Behaviour
       const jsonStr = await getJsonFromInputFile("knip-report.json");
-
       expect(() => JSON.parse(jsonStr)).not.toThrow();
     });
 
@@ -805,8 +805,9 @@ src/x.ts
 
       vi.spyOn(fs, "stat").mockRejectedValueOnce(new Error("File not found"));
 
+      // Behaviour
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided jsonReportPath does not exist: ${filePath}`,
+        `Provided 'json_report_path' does not exist: ${filePath}`,
       );
     });
 
@@ -816,8 +817,9 @@ src/x.ts
       vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
       vi.spyOn(fs, "readFile").mockResolvedValueOnce("");
 
+      // Behaviour
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided jsonReportPath is empty: ${filePath}`,
+        `Provided 'json_report_path' is empty: ${filePath}`,
       );
     });
 
@@ -827,8 +829,9 @@ src/x.ts
       vi.spyOn(fs, "stat").mockResolvedValueOnce({} as Stats);
       vi.spyOn(fs, "readFile").mockResolvedValueOnce("This is not JSON");
 
+      // Behaviour
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided jsonReportPath contains invalid JSON: ${filePath}`,
+        `Provided 'json_report_path' content contains invalid JSON: ${filePath}`,
       );
     });
   });

--- a/src/tasks/knip.spec.ts
+++ b/src/tasks/knip.spec.ts
@@ -806,7 +806,7 @@ src/x.ts
       vi.spyOn(fs, "stat").mockRejectedValueOnce(new Error("File not found"));
 
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided outputJsonFile does not exist: ${filePath}`,
+        `Provided jsonReportPath does not exist: ${filePath}`,
       );
     });
 
@@ -817,7 +817,7 @@ src/x.ts
       vi.spyOn(fs, "readFile").mockResolvedValueOnce("");
 
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided outputJsonFile is empty: ${filePath}`,
+        `Provided jsonReportPath is empty: ${filePath}`,
       );
     });
 
@@ -828,7 +828,7 @@ src/x.ts
       vi.spyOn(fs, "readFile").mockResolvedValueOnce("This is not JSON");
 
       await expect(getJsonFromInputFile(filePath)).rejects.toThrow(
-        `Provided outputJsonFile contains invalid JSON: ${filePath}`,
+        `Provided jsonReportPath contains invalid JSON: ${filePath}`,
       );
     });
   });

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -561,20 +561,20 @@ export function getJsonFromOutput(output: string): string {
 export async function getJsonFromInputFile(filePath: string): Promise<string> {
   try {
     await fs.stat(filePath);
-  } catch {
-    throw new Error(`Provided jsonReportPath does not exist: ${filePath}`);
+  } catch (err) {
+    throw new Error(`Provided 'json_report_path' does not exist: ${filePath}`, { cause: err });
   }
 
   const content = await fs.readFile(filePath, "utf-8");
 
   if (!content) {
-    throw new Error(`Provided jsonReportPath is empty: ${filePath}`);
+    throw new Error(`Provided 'json_report_path' is empty: ${filePath}`);
   }
 
   try {
     JSON.parse(content);
   } catch {
-    throw new Error(`Provided jsonReportPath contains invalid JSON: ${filePath}`);
+    throw new Error(`Provided 'json_report_path' content contains invalid JSON: ${filePath}`);
   }
 
   return content;

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -580,6 +580,16 @@ export async function getJsonFromInputFile(filePath: string): Promise<string> {
   return content;
 }
 
+async function getOutput(buildScriptName: string, cwd?: string): Promise<string> {
+  if (!buildScriptName) {
+    throw new Error("No command script name provided to run Knip, unable to proceed");
+  }
+
+  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
+
+  return getJsonFromOutput(await run(cmd));
+}
+
 export async function runKnipTasks(
   buildScriptName: string,
   outputJsonFile: string | undefined,
@@ -590,14 +600,9 @@ export async function runKnipTasks(
   const taskMs = Date.now();
   core.info("- Running Knip tasks");
 
-  const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
-  const output = await timeTask("Get knip report", async () => {
-    if (outputJsonFile) {
-      return getJsonFromInputFile(outputJsonFile);
-    }
-
-    return getJsonFromOutput(await run(cmd));
-  });
+  const output = outputJsonFile
+    ? await timeTask("Get knip report from file", () => getJsonFromInputFile(outputJsonFile))
+    : await timeTask("Run knip", () => getOutput(buildScriptName, cwd));
   const report = await timeTask("Parse knip report", () =>
     Promise.resolve(parseJsonReport(output)),
   );

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -590,13 +590,21 @@ async function getOutput(buildScriptName: string, cwd?: string): Promise<string>
   return getJsonFromOutput(await run(cmd));
 }
 
-export async function runKnipTasks(
-  buildScriptName: string,
-  jsonReportPath: string | undefined,
-  annotationsEnabled: boolean,
-  verboseEnabled: boolean,
-  cwd?: string,
-): Promise<{ sections: string[]; annotations: ItemMeta[] }> {
+export interface RunKnipTasksOpts {
+  buildScriptName: string;
+  jsonReportPath?: string;
+  annotationsEnabled: boolean;
+  verboseEnabled: boolean;
+  cwd?: string;
+}
+
+export async function runKnipTasks({
+  buildScriptName,
+  jsonReportPath,
+  annotationsEnabled,
+  verboseEnabled,
+  cwd,
+}: RunKnipTasksOpts): Promise<{ sections: string[]; annotations: ItemMeta[] }> {
   const taskMs = Date.now();
   core.info("- Running Knip tasks");
 

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -562,19 +562,19 @@ export async function getJsonFromInputFile(filePath: string): Promise<string> {
   try {
     await fs.stat(filePath);
   } catch {
-    throw new Error(`Provided outputJsonFile does not exist: ${filePath}`);
+    throw new Error(`Provided jsonReportPath does not exist: ${filePath}`);
   }
 
   const content = await fs.readFile(filePath, "utf-8");
 
   if (!content) {
-    throw new Error(`Provided outputJsonFile is empty: ${filePath}`);
+    throw new Error(`Provided jsonReportPath is empty: ${filePath}`);
   }
 
   try {
     JSON.parse(content);
   } catch {
-    throw new Error(`Provided outputJsonFile contains invalid JSON: ${filePath}`);
+    throw new Error(`Provided jsonReportPath contains invalid JSON: ${filePath}`);
   }
 
   return content;
@@ -592,7 +592,7 @@ async function getOutput(buildScriptName: string, cwd?: string): Promise<string>
 
 export async function runKnipTasks(
   buildScriptName: string,
-  outputJsonFile: string | undefined,
+  jsonReportPath: string | undefined,
   annotationsEnabled: boolean,
   verboseEnabled: boolean,
   cwd?: string,
@@ -600,8 +600,8 @@ export async function runKnipTasks(
   const taskMs = Date.now();
   core.info("- Running Knip tasks");
 
-  const output = outputJsonFile
-    ? await timeTask("Get knip report from file", () => getJsonFromInputFile(outputJsonFile))
+  const output = jsonReportPath
+    ? await timeTask("Get knip report from file", () => getJsonFromInputFile(jsonReportPath))
     : await timeTask("Run knip", () => getOutput(buildScriptName, cwd));
   const report = await timeTask("Parse knip report", () =>
     Promise.resolve(parseJsonReport(output)),

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -1,4 +1,5 @@
 import { exec } from "node:child_process";
+import fs from "node:fs/promises";
 
 import * as core from "@actions/core";
 import { parseNr, getCliCommand } from "@antfu/ni";
@@ -557,8 +558,31 @@ export function getJsonFromOutput(output: string): string {
   throw new Error("Unable to find JSON blob");
 }
 
+export async function getJsonFromInputFile(filePath: string): Promise<string> {
+  try {
+    await fs.stat(filePath);
+  } catch {
+    throw new Error(`Provided outputJsonFile does not exist: ${filePath}`);
+  }
+
+  const content = await fs.readFile(filePath, "utf-8");
+
+  if (!content) {
+    throw new Error(`Provided outputJsonFile is empty: ${filePath}`);
+  }
+
+  try {
+    JSON.parse(content);
+  } catch {
+    throw new Error(`Provided outputJsonFile contains invalid JSON: ${filePath}`);
+  }
+
+  return content;
+}
+
 export async function runKnipTasks(
   buildScriptName: string,
+  outputJsonFile: string | undefined,
   annotationsEnabled: boolean,
   verboseEnabled: boolean,
   cwd?: string,
@@ -567,7 +591,13 @@ export async function runKnipTasks(
   core.info("- Running Knip tasks");
 
   const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
-  const output = await timeTask("Run knip", async () => getJsonFromOutput(await run(cmd)));
+  const output = await timeTask("Get knip report", async () => {
+    if (outputJsonFile) {
+      return getJsonFromInputFile(outputJsonFile);
+    }
+
+    return getJsonFromOutput(await run(cmd));
+  });
   const report = await timeTask("Parse knip report", () =>
     Promise.resolve(parseJsonReport(output)),
   );

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -581,10 +581,6 @@ export async function getJsonFromInputFile(filePath: string): Promise<string> {
 }
 
 async function getOutput(buildScriptName: string, cwd?: string): Promise<string> {
-  if (!buildScriptName) {
-    throw new Error("No command script name provided to run Knip, unable to proceed");
-  }
-
   const cmd = await timeTask("Build knip command", () => buildRunKnipCommand(buildScriptName, cwd));
 
   return getJsonFromOutput(await run(cmd));


### PR DESCRIPTION
closes #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional json_report_path input to use a precomputed knip JSON report instead of running knip.

* **Behavior Changes**
  * json_report_path is resolved relative to the configured working directory (or current directory if unset).
  * When set, a warning is logged if a custom command script would be ignored.

* **Bug Fixes / Reliability**
  * Improved validation and clearer errors when reading the provided JSON report file.

* **Tests & Docs**
  * README updated and tests expanded to cover the new input and resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codex-/knip-reporter/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->