### PR TITLE
cicd: validate new builds in PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,26 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0 # Needed to compare new build to existing
       - uses: jdx/mise-action@v4
       - run: pnpm i
+      - name: Check if dist was modified in PR
+        id: dist-check
+        run: |
+          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- dist/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify committed build matches source
+        if: steps.dist-check.outputs.changed == 'true'
+        run: |
+          pnpm run build
+          if ! git diff --quiet -- dist/; then
+            echo "::error::Committed dist/ does not match the build output from src/. Run 'pnpm run build' and commit the result."
+            git --no-pager diff -- dist/
+            exit 1
+          fi
       - name: Knip Reporter
         uses: ./
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,10 @@ jobs:
         if: steps.dist-check.outputs.changed == 'true'
         run: |
           pnpm run build
-          if ! git diff --quiet -- dist/; then
+          status=$(git status --porcelain --untracked-files=all -- dist/)
+          if [ -n "$status" ]; then
             echo "::error::Committed dist/ does not match the build output from src/. Run 'pnpm run build' and commit the result."
+            echo "$status"
             git --no-pager diff -- dist/
             exit 1
           fi


### PR DESCRIPTION
If a new build is submitted in a PR we should be validating that the newly built distribution matches what would actually be generated from the sources so we don't implicitly commit or run maliciously injected sources 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request workflow with validation checks for build artifacts, ensuring consistency between committed and generated files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codex-/knip-reporter/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->