### PR TITLE
Fix split oversized sections into `n` chunks, not `n` * rows

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -24188,7 +24188,8 @@ function buildComments(cfgCommentId, reportSections) {
         continue;
       }
     }
-    if (section.length > GITHUB_COMMENT_MAX_COMMENT_LENGTH) {
+    const sectionUnpostable = section.length > GITHUB_COMMENT_MAX_COMMENT_LENGTH || currentCommentSections.length === 1 && newLength >= GITHUB_COMMENT_MAX_COMMENT_LENGTH;
+    if (sectionUnpostable) {
       const sectionHeader = section.split("\n")[0] ?? "";
       warning(`Section "${sectionHeader}" contents too long to post (${section.length})`);
       warning(`Skipping this section, please see output below:`);
@@ -28368,8 +28369,7 @@ function processSectionToMessages(sectionHeader, tableHeader, tableBody) {
   output = [];
   const splitFactor = Math.ceil(originalOutput.length / (GITHUB_COMMENT_MAX_COMMENT_LENGTH + 100));
   const tableBodySize = tableBody.length;
-  const tableBodySplitSize = Math.ceil(tableBodySize / splitFactor);
-  const tableBodyItemWindow = Math.ceil(tableBodySize / tableBodySplitSize);
+  const tableBodyItemWindow = Math.ceil(tableBodySize / splitFactor);
   let tableBodySliceStart = 0;
   let tableBodySliceEnd = tableBodyItemWindow;
   while (tableBodySliceStart < tableBodySize) {

--- a/src/tasks/__snapshots__/knip.spec.ts.snap
+++ b/src/tasks/__snapshots__/knip.spec.ts.snap
@@ -1729,3497 +1729,1509 @@ exports[`knip > processSectionToMessage > should return sections that are below 
 |-|-|-|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
-|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
-|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
-|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
-|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
-|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
-|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
-|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
-|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
+|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
+|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|",
   "### Unused Enum Members (12)
 
 |Filename|Enum|Member|
 |-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
+|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
+|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
+|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|",
   "### Unused Enum Members (12)
 
 |Filename|Enum|Member|
 |-|-|-|
+|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
+|DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
+|Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
-|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",
-  "### Unused Enum Members (12)
-
-|Filename|Enum|Member|
-|-|-|-|
+|Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|
 |DrNefarious.ts|Homeworld|\`Magmos\`<br/>\`Aquatos\`<br/>\`Leviathan \`<br/>\`TombliOutpost\`<br/>\`Zanifar \`<br/>\`NefariousSpaceStation \`<br/>\`NefariousCity\`<br/>\`CorsonV\`|
 |Sigmund.ts|Membership|\`ZordoomPrison\`<br/>\`GreatClockStaff\`|
 |Sigmund.ts|Residence|\`Viceron\`<br/>\`GreatClock\`|",

--- a/src/tasks/comment.spec.ts
+++ b/src/tasks/comment.spec.ts
@@ -1,10 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "../api.ts";
-import { mockLoggingFunctions } from "../test-utils/logging.mock.ts";
 import { reportJson } from "./__fixtures__/knip.fixture.ts";
 import { buildComments, createOrUpdateComments, deleteComments } from "./comment.ts";
 import { buildFilesSection, buildMarkdownSections, parseJsonReport } from "./knip.ts";
+import { mockLoggingFunctions } from "../test-utils/logging.mock.ts";
 
 vi.mock("@actions/core");
 vi.mock("../api.ts");
@@ -230,6 +230,27 @@ describe("comment", () => {
         `"Skipping this section, please see output below:"`,
       );
       expect(coreWarningLogMock.mock.calls[2]?.[0]).toStrictEqual(longSection[0]);
+    });
+
+    it("should skip a section whose length is in the borderline window above MAX - headerLen", () => {
+      // A section that is itself under MAX but, combined with the comment-id header
+      // + delimiter, exceeds MAX cannot fit in any comment.
+      // Earlier iterations of buildComments would loop forever on this case because
+      // neither the "fits" branch nor the "too long" branch advanced the section index.
+      const sectionHeader = "### Borderline";
+      const filler = "a".repeat(api.GITHUB_COMMENT_MAX_COMMENT_LENGTH - sectionHeader.length - 3);
+      const borderline = `${sectionHeader}\n\n${filler}`;
+      expect(borderline.length).toBeLessThan(api.GITHUB_COMMENT_MAX_COMMENT_LENGTH);
+
+      // Behaviour
+      const comments = buildComments("hello", [borderline]);
+      expect(comments).toHaveLength(0);
+
+      // Logging
+      assertOnlyCalled(coreDebugLogMock, coreWarningLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledTimes(3);
+      expect(coreWarningLogMock.mock.calls[0]?.[0]).toContain(sectionHeader);
+      expect(coreWarningLogMock.mock.calls[0]?.[0]).toContain(`(${borderline.length})`);
     });
 
     it("should not output a warning for a regular section", () => {

--- a/src/tasks/comment.ts
+++ b/src/tasks/comment.ts
@@ -53,7 +53,13 @@ export function buildComments(cfgCommentId: string, reportSections: string[]): s
       }
     }
 
-    if (section.length > GITHUB_COMMENT_MAX_COMMENT_LENGTH) {
+    // A section under MAX is still unpostable when combined with the comment-id
+    // header + delimiter would exceed MAX in an otherwise-empty comment. Without
+    // catching that here the loop never advances on such a section.
+    const sectionUnpostable =
+      section.length > GITHUB_COMMENT_MAX_COMMENT_LENGTH ||
+      (currentCommentSections.length === 1 && newLength >= GITHUB_COMMENT_MAX_COMMENT_LENGTH);
+    if (sectionUnpostable) {
       const sectionHeader = section.split("\n")[0] ?? "";
       core.warning(`Section "${sectionHeader}" contents too long to post (${section.length})`);
       core.warning(`Skipping this section, please see output below:`);

--- a/src/tasks/knip.spec.ts
+++ b/src/tasks/knip.spec.ts
@@ -14,7 +14,7 @@ import {
   type MockInstance,
 } from "vitest";
 
-import { mockLoggingFunctions } from "../test-utils/logging.mock.ts";
+import { GITHUB_COMMENT_MAX_COMMENT_LENGTH } from "../api.ts";
 import { invalidReportJson, reportJson } from "./__fixtures__/knip.fixture.ts";
 import {
   buildArraySection,
@@ -31,6 +31,7 @@ import {
   run,
   runKnipTasks,
 } from "./knip.ts";
+import { mockLoggingFunctions } from "../test-utils/logging.mock.ts";
 
 vi.mock("node:child_process");
 vi.mock("@actions/core");
@@ -46,8 +47,13 @@ vi.mock("@antfu/ni", async () => {
 });
 
 describe("knip", () => {
-  const { coreDebugLogMock, coreInfoLogMock, coreWarningLogMock, assertOnlyCalled } =
-    mockLoggingFunctions();
+  const {
+    coreDebugLogMock,
+    coreInfoLogMock,
+    coreWarningLogMock,
+    assertOnlyCalled,
+    assertNoneCalled,
+  } = mockLoggingFunctions();
 
   afterAll(() => {
     vi.restoreAllMocks();
@@ -739,6 +745,27 @@ describe("knip", () => {
 
       // Behaviour
       const messages = processSectionToMessages(sectionHeader, tableHeader, body);
+
+      // Chunk count is bounded by the number of comments required to fit the
+      // output. Earlier iterations produced ~500 chunks of 3 rows; the intended
+      // behaviour is a small number of large chunks.
+      expect(messages.length).toBeGreaterThan(1);
+      expect(messages.length).toBeLessThan(20);
+
+      // Each chunk fits in a comment and renders as a standalone section.
+      const tableHeaderLine = "|Filename|Enum|Member|";
+      let observedRows = 0;
+      for (const msg of messages) {
+        expect(msg.length).toBeLessThan(GITHUB_COMMENT_MAX_COMMENT_LENGTH);
+        expect(msg).toContain(sectionHeader);
+        expect(msg).toContain(tableHeaderLine);
+        observedRows += msg
+          .split("\n")
+          .filter((l) => l.startsWith("|") && l !== tableHeaderLine && !l.startsWith("|-")).length;
+      }
+      // Every input row appears exactly once across the chunks.
+      expect(observedRows).toBe(body.length);
+
       expect(messages).toMatchSnapshot();
 
       // Logging
@@ -750,6 +777,25 @@ describe("knip", () => {
       expect(coreInfoLogMock.mock.calls[1]?.[0]).toMatch(
         /^ {4}✔ Splitting section ### Unused Enum Members \(12\) \(\d+ms\)$/,
       );
+    });
+
+    it("should return a single message when the section fits in one comment", () => {
+      const sectionHeader = "### Small";
+      const tableHeader = ["File", "Item"];
+      const tableBody = [
+        ["foo.ts", "`bar`"],
+        ["baz.ts", "`qux`"],
+      ];
+
+      // Behaviour
+      const messages = processSectionToMessages(sectionHeader, tableHeader, tableBody);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toContain(sectionHeader);
+      expect(messages[0]).toContain("|File|Item|");
+      expect(messages[0]?.length).toBeLessThan(GITHUB_COMMENT_MAX_COMMENT_LENGTH);
+
+      // Logging: no splitting → no logs
+      assertNoneCalled();
     });
   });
 

--- a/src/tasks/knip.ts
+++ b/src/tasks/knip.ts
@@ -436,8 +436,7 @@ export function processSectionToMessages(
   // Adding 100 to the limit to give us a bit of wiggle room when splitting the section
   const splitFactor = Math.ceil(originalOutput.length / (GITHUB_COMMENT_MAX_COMMENT_LENGTH + 100));
   const tableBodySize = tableBody.length;
-  const tableBodySplitSize = Math.ceil(tableBodySize / splitFactor);
-  const tableBodyItemWindow = Math.ceil(tableBodySize / tableBodySplitSize);
+  const tableBodyItemWindow = Math.ceil(tableBodySize / splitFactor);
   let tableBodySliceStart = 0;
   let tableBodySliceEnd = tableBodyItemWindow;
   while (tableBodySliceStart < tableBodySize) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a critical issue where the application could stall indefinitely when attempting to generate GitHub comments with oversized content sections. The system now properly detects sections that cannot be posted and alerts users with clear warnings.

* **Improvements**
  * Optimized how content is split and distributed across multiple GitHub comment posts for better handling of large data tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codex-/knip-reporter/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->